### PR TITLE
Modified oncomplete so it returns the object it was tweening

### DIFF
--- a/flux.lua
+++ b/flux.lua
@@ -167,7 +167,7 @@ function flux:update(deltatime)
       if t._onupdate then t._onupdate() end
       if p >= 1 then
         flux.remove(self, i)
-        if t._oncomplete then t._oncomplete() end
+        if t._oncomplete then t._oncomplete(t.obj) end
       end
     end
   end


### PR DESCRIPTION
This small change makes it very easy to chain together tweens and create repeats. For example.

local function tweenRepeat(obj)
    Flux.to(obj, 4, {x = 10}):after(4, {x = 0}):oncomplete(tweenRepeat)
end

tweenRepeat(FanceObject:new())